### PR TITLE
Switch to Next.js app router

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # codex
+
+This repository now uses Next.js with the App Router. The main entry point is in the `app/` directory.
+
+## Running locally
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Start the development server
+   ```bash
+   npm run dev
+   ```
+
+The homepage is defined in `app/page.js` and API routes live under `app/api/`.

--- a/app/api/posts/[id]/route.js
+++ b/app/api/posts/[id]/route.js
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+
+let posts = [];
+
+export async function GET(request, { params }) {
+  const post = posts.find(p => p.id === params.id);
+  if (!post) return NextResponse.json({ message: 'Not Found' }, { status: 404 });
+  return NextResponse.json(post);
+}
+
+export async function PUT(request, { params }) {
+  const index = posts.findIndex(p => p.id === params.id);
+  if (index === -1) return NextResponse.json({ message: 'Not Found' }, { status: 404 });
+  const data = await request.json();
+  posts[index] = { ...posts[index], ...data };
+  return NextResponse.json(posts[index]);
+}
+
+export async function DELETE(request, { params }) {
+  const index = posts.findIndex(p => p.id === params.id);
+  if (index === -1) return NextResponse.json({ message: 'Not Found' }, { status: 404 });
+  const removed = posts.splice(index, 1);
+  return NextResponse.json(removed[0]);
+}

--- a/app/api/posts/route.js
+++ b/app/api/posts/route.js
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+let posts = [];
+
+export async function GET() {
+  return NextResponse.json(posts);
+}
+
+export async function POST(request) {
+  const data = await request.json();
+  const newPost = { id: Date.now().toString(), ...data };
+  posts.push(newPost);
+  return NextResponse.json(newPost, { status: 201 });
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <main>
+      <h1>Welcome to the App Router Homepage</h1>
+    </main>
+  );
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: { appDir: true },
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "codex",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.19",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}


### PR DESCRIPTION
## Summary
- set up minimal Next.js 13+ app structure
- add `app/page.js` homepage using the new `Page` component format
- implement API routes under `app/api/posts` with `NextResponse`
- configure `next.config.js` with `experimental.appDir`
- document how to run the app

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6841e34d4d8c8324aafa11e13d1e402e